### PR TITLE
Added simple function for masking bad pixel bands in LS7 images.

### DIFF
--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+def LS7_band_mask(rgb_raster):
+    '''
+    Returns a mask for the bands of empty pixels in the Landsat 7 images.
+
+    The function looks for pixels that have a zero value for all red, green, and blue
+    bands.
+
+    Args:
+        rgb_raster (rasterio.io.DatasetReader): ``rasterio.io.DatasetReader`` object with red, green, and blue bands.
+
+    Returns:
+        Mask for zero value bands. 
+    '''
+
+    mask = np.where(
+        np.logical_and(
+            rgb_raster.read(1) == 0,
+            np.logical_and(
+                rgb_raster.read(2) == 0,
+                rgb_raster.read(3) == 0
+            )
+        ),
+        1,
+        0
+    )
+
+    return mask


### PR DESCRIPTION
Function addressing #3.

Landsat 7 images have 'bands' or 'stripes' in images post ~2003. This caused by the Scan Line Corrector (SLC) failing, see [here](https://www.usgs.gov/faqs/what-landsat-7-etm-slc-data).

The easiest way to mask these stripes is to just look for pixels where all bands are zero, so that's what this function does.

Tested on Colab with `2022-07-01/LS/LE07_202025_20220714.tif` and appears to work fine.