### PR TITLE
Added function that finds cloudy and pixel counts from QA bitmask.

### DIFF
--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -42,7 +42,6 @@ def QA_cloud_perc(file_list, QA_band):
     '''
 
     # Define some empty arrays for the counts.
-    cloud_count = np.zero((len(file_list, )))
     water_count = np.zeros((len(file_list, )))
 
     # Loop over all files.

--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -44,7 +44,7 @@ def QA_cloud_perc(file_list, QA_band):
 
     # Define some empty arrays for the counts.
     cloud_count = np.zero((len(file_list, )))
-    land_count = np.zeros((len(file_list, )))
+    water_count = np.zeros((len(file_list, )))
 
     # Loop over all files.
     for i, fi in enumerate(file_list):
@@ -56,20 +56,20 @@ def QA_cloud_perc(file_list, QA_band):
         # I have assumed these will be different functions but I guess they don't need to be.
         cloud_i = cloud_from_bitmask(QA)
         shadow_i = shadow_from_bitmask(QA)
-        land_i = land_from_bitmask(QA)
+        water_i = water_from_bitmask(QA)
 
         # Simply sum the boolean masks to find the total counts
         cloud_count[i] = np.sum(cloud_i)+np.sum(shadow_i)
-        land_count[i] = np.sum(land_i)
+        water_count[i] = np.sum(water_i)
 
-    return cloud_count, land_count
+    return cloud_count, water_count
 
 def cloud_from_bitmask(bitmask):
     
     
     return
 
-def land_from_bitmask(bitmask):
+def water_from_bitmask(bitmask):
     
     
     return

--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -31,15 +31,14 @@ def LS7_band_mask(rgb_raster):
 
 def QA_cloud_perc(file_list, QA_band):
     '''
-    With a given list of ``.tif`` files that contain ``QA_PIXEL`` find the number of cloudy or shadowy pixels 
-    along with the number of land pixels according to the bitmask
+    With a given list of ``.tif`` files that contain ``QA_PIXEL`` find the number of water pixels
+    according to the bitmask
 
     Args:
         file_list (list): List of file names.
         QA_band (int): The band id for the ``QA_PIXEL`` bitmask.
     Returns:
-        cloud_count (array): Nummber of cloudy or shadowy pixels in each file, will have same length as ``file_list``.
-        land_count (array): Nummber of land pixels in each file, will have same length as ``file_list``.
+        water_count (array): Nummber of water pixels in each file, will have same length as ``file_list``.
     '''
 
     # Define some empty arrays for the counts.
@@ -52,29 +51,15 @@ def QA_cloud_perc(file_list, QA_band):
         # Load bitmask
         QA = rasterio.open(fi).read(QA_band)
 
-        # Find the boolean masks from the bit mask.
-        # I have assumed these will be different functions but I guess they don't need to be.
-        cloud_i = cloud_from_bitmask(QA)
-        shadow_i = shadow_from_bitmask(QA)
+        # Find the boolean mask from the bit mask.
         water_i = water_from_bitmask(QA)
 
         # Simply sum the boolean masks to find the total counts
-        cloud_count[i] = np.sum(cloud_i)+np.sum(shadow_i)
         water_count[i] = np.sum(water_i)
 
-    return cloud_count, water_count
-
-def cloud_from_bitmask(bitmask):
-    
-    
-    return
+    return water_count
 
 def water_from_bitmask(bitmask):
-    
-    
-    return
-
-def shadow_from_bitmask(bitmask):
     
     
     return

--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -85,7 +85,7 @@ def water_from_bitmask(bitmask):
         bitmask_bits[:, :, bit_ix] = fetch_bit_func(strs).astype("int8")
 
     # The water bitmask is stored in bit 7 (index 15-7=8).
-    water_bitmask = bitmask_bits[:, :, 8] == 0
+    water_bitmask = bitmask_bits[:, :, 8] == 1
 
     return water_bitmask
 

--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -1,4 +1,5 @@
 import numpy as np
+import rasterio
 
 def LS7_band_mask(rgb_raster):
     '''
@@ -27,3 +28,53 @@ def LS7_band_mask(rgb_raster):
     )
 
     return mask
+
+def QA_cloud_perc(file_list, QA_band):
+    '''
+    With a given list of ``.tif`` files that contain ``QA_PIXEL`` find the number of cloudy or shadowy pixels 
+    along with the number of land pixels according to the bitmask
+
+    Args:
+        file_list (list): List of file names.
+        QA_band (int): The band id for the ``QA_PIXEL`` bitmask.
+    Returns:
+        cloud_count (array): Nummber of cloudy or shadowy pixels in each file, will have same length as ``file_list``.
+        land_count (array): Nummber of land pixels in each file, will have same length as ``file_list``.
+    '''
+
+    # Define some empty arrays for the counts.
+    cloud_count = np.zero((len(file_list, )))
+    land_count = np.zeros((len(file_list, )))
+
+    # Loop over all files.
+    for i, fi in enumerate(file_list):
+
+        # Load bitmask
+        QA = rasterio.open(fi).read(QA_band)
+
+        # Find the boolean masks from the bit mask.
+        # I have assumed these will be different functions but I guess they don't need to be.
+        cloud_i = cloud_from_bitmask(QA)
+        shadow_i = shadow_from_bitmask(QA)
+        land_i = land_from_bitmask(QA)
+
+        # Simply sum the boolean masks to find the total counts
+        cloud_count[i] = np.sum(cloud_i)+np.sum(shadow_i)
+        land_count[i] = np.sum(land_i)
+
+    return cloud_count, land_count
+
+def cloud_from_bitmask(bitmask):
+    
+    
+    return
+
+def land_from_bitmask(bitmask):
+    
+    
+    return
+
+def shadow_from_bitmask(bitmask):
+    
+    
+    return

--- a/pkg/image_fns.py
+++ b/pkg/image_fns.py
@@ -60,6 +60,49 @@ def QA_cloud_perc(file_list, QA_band):
     return water_count
 
 def water_from_bitmask(bitmask):
-    
-    
-    return
+    '''
+    Converts a earth engine QA bitmask to a boolean array of water pixels.
+    Bitmask array conversion from https://stackoverflow.com/questions/22227595/convert-integer-to-binary-array-with-suitable-padding
+    Arguments:
+    bitmask:np.ndarray, shape(pix_x, pix_y)
+
+    returns:
+    water_bitmask : np.ndarray, shape(pix_x, pix_y). Boolean array of pixels where water is present 
+    '''
+
+    # number of bits to convert bitmask to 
+    m = 16 
+    # Function to convert an integer to a string binary representation
+    to_str_func = np.vectorize(lambda x: np.binary_repr(x).zfill(m))
+    # Calculte binary representations
+    strs = to_str_func(bitmask)
+    # Create empty array for the bitmask
+    bitmask_bits = np.zeros(list(bitmask.shape) + [m], dtype=np.int8)
+    # Iterate over all m  bits
+    for bit_ix in range(0, m):
+        # Get the bits
+        fetch_bit_func = np.vectorize(lambda x: x[bit_ix] == '1')
+        # Store the bits
+        bitmask_bits[:, :, bit_ix] = fetch_bit_func(strs).astype("int8")
+
+    # The water bitmask is stored in bit 7 (index 15-7=8).
+    water_bitmask = bitmask_bits[:, :, 8] == 0
+
+    return water_bitmask
+
+def calculate_cloud_percentage(water_counts):
+    '''
+    Calculates the percentage of water covered by clouds for a given array
+    of sums of water pixels. Assumes the maximum water count corresponds to the 
+    clearest, least cloudy day and calculates the percentages from there. 
+
+    Arguments:
+    water_counts : np.ndarray, shape (n_files,), counts of all water pixels for a given image
+
+    Returns:
+    cover_percents : np.ndarray, shape (n_files), percentage of cloud cover for a given image
+
+    '''
+    cover_percents = 100*(water_counts / water_counts.max())
+
+    return cover_percents


### PR DESCRIPTION
The aim here is to try and find the number of pixels that are assigned as cloud or land in the `QA_PIXEL` bitmask. We can then uses these counts to find the percentage of ocean pixels that are cloudy under the assumption that the maximum value for the land pixel count will correspond to a clear scene.